### PR TITLE
Allow CORS headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ coreschema==0.0.4
 cryptography==3.2
 defusedxml==0.7.0rc1
 Django==3.0.7
+django-cors-headers==3.7.0
 django-filter==2.3.0
 djangorestframework==3.11.0
 drf-yasg==1.17.1

--- a/server/settings.py
+++ b/server/settings.py
@@ -26,7 +26,10 @@ SECRET_KEY = config('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
+
+CORS_ALLOW_CREDENTIALS = True
+CORS_ORIGIN_ALLOW_ALL = True
 
 
 # Application definition
@@ -42,13 +45,15 @@ INSTALLED_APPS = [
     'drf_yasg',
     'social_django',
     'profiles',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+    #'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',


### PR DESCRIPTION
As discussed with the frontend team, allowing CORS headers is required to develop the frontend of the leaderboard. This PR does that.

To test this, I'm referring to [this repository](https://github.com/cactuz/cors-tester-from-browser).
Create the following files
`index.html`

```
<!DOCTYPE html>
<html>
<head>
  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
  <meta http-equiv="Content-Style-Type" content="text/css">
  <title>CORS Tester</title>
  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.0/jquery.min.js"></script>
</head>
<body>
  <H2>To view test result</H2>
  <h3>Right click this page > Inspect Element > Console </h3>
  <p id="out"></p>

  <script>
  console.log("starting ajax request to the resource.");
  $.ajax
      ({type: "GET",                     //edit method
          contentType: "json",           //edit datatype: json, html, etc.dataType: "json",
          url: "http://localhost:8000/leaderboard/", //edit host and port, example: http://198.0.1.20:8443/pat
        headers: {                       //add any headers here
          },
          xhrFields: {                   //optional
                withCredentials: true
            },
      success: function(data)
      {
        console.log("API is CORS enabled, here's the result");
        console.log(data);
        $('#out').text(JSON.stringify(data));
      },
          done: function( jqXHR, textStatus ) {
          console.log( "Request failed: " + textStatus + jqXHR );
      },
    });
  console.log("ajax request sent.");
  </script>
</body>
</html>
```
and `server.js`
```
var connect = require('connect');
   var serveStatic = require('serve-static');
   connect().use(serveStatic(__dirname)).listen(8080, function(){
       console.log('Server running on 8080...');
   });
```
and run `npm install connect serve-static` (make sure you have `node` installed).
Run `node server.js` to test the server and test the cosole output on `http://localhost:8080/index.html` (make sure `index.html` and `server.js` are in the same directory).

the following should be the output:
<img width="1440" alt="Screenshot 2021-02-16 at 8 46 52 PM" src="https://user-images.githubusercontent.com/30956619/108082492-2ac7a900-7098-11eb-9a17-ed9d8710669f.png">
